### PR TITLE
Optionally allow host-mode networking

### DIFF
--- a/director.go
+++ b/director.go
@@ -24,9 +24,10 @@ var (
 )
 
 type rulesDirector struct {
-	Client     *http.Client
-	Owner      string
-	AllowBinds []string
+	Client                  *http.Client
+	Owner                   string
+	AllowBinds              []string
+	AllowHostModeNetworking bool
 }
 
 func writeError(w http.ResponseWriter, msg string, code int) {
@@ -233,7 +234,7 @@ func (r *rulesDirector) handleContainerCreate(l *log.Logger, req *http.Request, 
 
 		// prevent host and container network mode
 		networkMode, ok := decoded["HostConfig"].(map[string]interface{})["NetworkMode"].(string)
-		if ok && networkMode == "host" {
+		if ok && networkMode == "host" && (!r.AllowHostModeNetworking) {
 			l.Printf("Denied host network mode on container create")
 			writeError(w, "Containers aren't allowed to use host networking", http.StatusUnauthorized)
 			return

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	upstream := flag.String("upstream-socket", "/var/run/docker.sock", "The path to the original docker socket")
 	owner := flag.String("owner-label", "", "The value to use as the owner of the socket, defaults to the process id")
 	allowBind := flag.String("allow-bind", "", "A path to allow host binds to occur under")
+	allowHostModeNetworking := flag.Bool("allow-host-mode-networking", false, "Allow containers to run with --net host")
 	flag.Parse()
 
 	if debug {
@@ -44,8 +45,9 @@ func main() {
 	}
 
 	proxy := socketproxy.New(*upstream, &rulesDirector{
-		AllowBinds: allowBinds,
-		Owner:      *owner,
+		AllowBinds:              allowBinds,
+		AllowHostModeNetworking: *allowHostModeNetworking,
+		Owner: *owner,
 		Client: &http.Client{
 			Transport: &http.Transport{
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {


### PR DESCRIPTION
This adds a flag, `-allow-host-mode-networking`.  When set, containers will be allowed to be created with `-network host` enabled.  Host-mode networking is needed for some environments like a Kubernetes cluster running a network overlay like Calico.  

Eventually, it would be nice if sockguard could detect a network overlay and set networking to container mode and point it at the correct container that's handling the overlay.