### PR TITLE
Allow /auth endpoint to be used

### DIFF
--- a/director.go
+++ b/director.go
@@ -59,7 +59,10 @@ func (r *rulesDirector) Direct(l *log.Logger, req *http.Request, upstream http.H
 	}
 
 	switch {
+	// System related endpoints
 	case match(`GET`, `^/(_ping|version|info)$`):
+		return upstream
+	case match(`POST`, `^/auth$`):
 		return upstream
 
 	// Container related endpoints


### PR DESCRIPTION
This allows the `/auth` endpoint to be used.   `/auth` is needed for things like authenticating to AWS ECR.