### PR TITLE
Configurable Label Name + Optional CgroupParent as Label Value

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		*labelValue = &useLabelValue
+		*labelValue = useLabelValue
 	} else if *labelValue == "" {
 		*labelValue = fmt.Sprintf("sockguard-pid-%d", os.Getpid())
 	}


### PR DESCRIPTION
This PR adds 2 features + changes the way `--owner-label` works for consistency:

- The ability to specify the `--label-name` used for new resources/filtering (defaults to the previous `com.buildkite.sockguard.owner` key/name)
- The ability to use `--label-value` (instead of `--owner-label`) to set an arbitrary value for the label.
  - If you use `--owner-label` it will output a deprecated error explaining to use the new syntax
  - Default value is the same `sockguard-pid-#` value if no flag specified
- Adds an optional `--label-value-cgroup-parent` flag to use the value of `CgroupParent` on the running container as the label.
  - This allows doing some creative things such as "auto GC" of all resources created via this `sockguard` instance on termination of some sidecar (eg. a well configured [docker-gc](https://github.com/spotify/docker-gc))
  - For our infra, I plan to run a bash wrapper in a container, that when it detects `SIGTERM` it will fire off `docker-gc` and cleanup all resources with the right label, regardless of age.
  - This ensures when our Jenkins agent ECS task terminates, it cleans up anything left behind by the running job (we have found different test suites notorious for leaving junk running to cleanup later)

Note: for this to cleanly merge/build, we need https://github.com/buildkite/sockguard/pull/5 finalised and merged to master. Feel free to review what is going on here in the meantime, but don't merge until the other PR is done and dusted, thx.