### PR TITLE
Fix networks regex

### DIFF
--- a/director.go
+++ b/director.go
@@ -117,9 +117,9 @@ func (r *rulesDirector) Direct(l socketproxy.Logger, req *http.Request, upstream
 		return r.addLabelsToBody(l, req, upstream)
 	case match(`POST`, `^/networks/prune$`):
 		return r.addLabelsToQueryStringFilters(l, req, upstream)
-	case match(`GET`, `^/networks/(\w+)$`),
-		match(`DELETE`, `^/networks/(\w+)$`),
-		match(`POST`, `^/networks/(\w+)/(connect|disconnect)$`):
+	case match(`GET`, `^/networks/(.+)$`),
+		match(`DELETE`, `^/networks/(.+)$`),
+		match(`POST`, `^/networks/(.+)/(connect|disconnect)$`):
 		if ok, err := r.checkOwner(l, "networks", true, req); ok {
 			return upstream
 		} else if err == errInspectNotFound {

--- a/director.go
+++ b/director.go
@@ -155,7 +155,7 @@ func (r *rulesDirector) Direct(l socketproxy.Logger, req *http.Request, upstream
 
 var identifierPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^/containers/(.+?)(?:/\w+)?$`),
-	regexp.MustCompile(`^/networks/(\w+?)(?:/\w+)?$`),
+	regexp.MustCompile(`^/networks/(.+?)(?:/\w+)?$`),
 	regexp.MustCompile(`^/volumes/(\w+?)(?:/\w+)?$`),
 	regexp.MustCompile(`^/images/(.+?)/(?:json|history|push|tag)$`),
 	regexp.MustCompile(`^/images/([^/]+)$`),


### PR DESCRIPTION
Networks can have at least a dash in them, in addition to `[a-zA-Z0-9_]`. Didn't check upstream to see what the limitations are on names, but I suspect other characters might be permitted also. Just open it up to all chars.

We might need to mod a few more of these regexes over time, this is a start. Tested in our infrastructure - working correctly.