### PR TITLE
examples/cgroup_parent: change the ci_agent_dev Dockerfile to be more useful

### DIFF
--- a/examples/cgroup_parent/ci_agent_dev/Dockerfile
+++ b/examples/cgroup_parent/ci_agent_dev/Dockerfile
@@ -1,7 +1,21 @@
-FROM alpine:3.8
+FROM debian:stretch
+
+RUN apt-get update && \
+    apt-get install -y curl && \
+    rm -rf /var/run/apt/lists/*
 
 # Install docker so we can test the unix socket
-RUN apk add --no-cache bash docker
+ENV DOCKER_VERSION 18.06.1
+RUN curl -O "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}-ce.tgz" && \
+    tar xzf "docker-${DOCKER_VERSION}-ce.tgz" && \
+    mv /docker/docker /usr/bin/docker && \
+    rm -rf /docker && \
+    rm -rf "docker-${DOCKER_VERSION}-ce.tgz"
+
+# Also install docker-compose, for testing/misc
+ENV DOCKER_COMPOSE_VERSION 1.22.0
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/bin/docker-compose && \
+    chmod +x /usr/bin/docker-compose
 
 COPY ./start.sh /start.sh
 


### PR DESCRIPTION
Includes `docker-compose` + `docker` by default.

Note: I tried to do this under `alpine:3.8` but due to musl libc the
`docker-compose` (python) binary doesn't work cleanly, and it's messier to
install `pip` etc for it. just changed to debian:stretch instead