### PR TITLE
Simplify logic around adding a label to filters

### DIFF
--- a/director.go
+++ b/director.go
@@ -331,7 +331,8 @@ func (r *rulesDirector) addLabelsToQueryStringFilters(l socketproxy.Logger, req 
 		var q = req.URL.Query()
 		var filters = map[string][]string{}
 
-		// parse existing filters
+		// parse existing filters from querystring
+		// see https://docs.docker.com/engine/api/v1.30/#operation/ContainerList
 		if q.Get("filters") != "" {
 			if err := json.NewDecoder(strings.NewReader(q.Get("filters"))).Decode(&filters); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)

--- a/director.go
+++ b/director.go
@@ -328,22 +328,36 @@ func (r *rulesDirector) addLabelsToBody(l socketproxy.Logger, req *http.Request,
 
 func (r *rulesDirector) addLabelsToQueryStringFilters(l socketproxy.Logger, req *http.Request, upstream http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		err := modifyRequestFilters(req, func(filters map[string][]interface{}) {
-			label := ownerKey + "=" + r.Owner
-			l.Printf("Adding label %v to label filters %v", label, filters["label"])
-			filters["label"] = []interface{}{label}
-			for _, val := range filters["label"] {
-				if valString, ok := val.(string); ok {
-					if valString != ownerKey && !strings.HasPrefix(valString, ownerKey+"=") {
-						filters["label"] = append(filters["label"], valString)
-					}
-				}
+		var q = req.URL.Query()
+		var filters = map[string][]string{}
+
+		// parse existing filters
+		if q.Get("filters") != "" {
+			if err := json.NewDecoder(strings.NewReader(q.Get("filters"))).Decode(&filters); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
 			}
-		})
+		}
+
+		// add an label slice if none exists
+		if _, exists := filters["label"]; !exists {
+			filters["label"] = []string{}
+		}
+
+		// add an owner label
+		label := ownerKey + "=" + r.Owner
+		l.Printf("Adding label %v to label filters %v", label, filters["label"])
+		filters["label"] = append(filters["label"], label)
+
+		// encode back into json
+		encoded, err := json.Marshal(filters)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+
+		q.Set("filters", string(encoded))
+		req.URL.RawQuery = q.Encode()
 
 		upstream.ServeHTTP(w, req)
 	})
@@ -426,44 +440,6 @@ func (r *rulesDirector) inspectLabels(kind, id string) (map[string]string, error
 	}
 
 	return nil, fmt.Errorf("Unknown kind %q", kind)
-}
-
-func modifyRequestFilters(req *http.Request, f func(filters map[string][]interface{})) error {
-	var filters = map[string][]interface{}{}
-	var q = req.URL.Query()
-
-	if encoded := q.Get("filters"); encoded != "" {
-		var generic map[string]interface{}
-
-		log.Printf("filters=%q", encoded)
-		if err := json.NewDecoder(strings.NewReader(encoded)).Decode(&generic); err != nil {
-			return err
-		}
-		for k, v := range generic {
-			switch tv := v.(type) {
-			case map[string]interface{}:
-				for mk, mv := range tv {
-					log.Printf("Adding %s = %v", mk, mv)
-					filters[k] = []interface{}{mk}
-				}
-			default:
-				log.Printf("[%s] Got type %T: %v", k, v, tv)
-			}
-		}
-
-		log.Printf("%#v", filters)
-	}
-
-	f(filters)
-
-	encoded, err := json.Marshal(filters)
-	if err != nil {
-		return err
-	}
-
-	q.Set("filters", string(encoded))
-	req.URL.RawQuery = q.Encode()
-	return nil
 }
 
 func modifyRequestBody(req *http.Request, f func(filters map[string]interface{})) error {

--- a/director.go
+++ b/director.go
@@ -332,7 +332,6 @@ func (r *rulesDirector) addLabelsToQueryStringFilters(l socketproxy.Logger, req 
 		var filters = map[string][]interface{}{}
 
 		// parse existing filters from querystring
-		// see https://docs.docker.com/engine/api/v1.30/#operation/ContainerList
 		if qf := q.Get("filters"); qf != "" {
 			var existing map[string]interface{}
 
@@ -341,6 +340,7 @@ func (r *rulesDirector) addLabelsToQueryStringFilters(l socketproxy.Logger, req 
 				return
 			}
 
+			// different docker implementations send us different data structures
 			for k, v := range existing {
 				switch tv := v.(type) {
 				// sometimes we get a map of value=true

--- a/director_test.go
+++ b/director_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+)
+
+// Reusable mock rulesDirector instance
+func mockRulesDirector() *rulesDirector {
+	rdhc := &http.Client{}
+	return &rulesDirector{
+		Client: rdhc,
+		Owner:  "test-owner",
+		AllowHostModeNetworking: false,
+	}
+}
+
+// Reusable mock log.Logger instance
+func mockLogger() *log.Logger {
+	return log.New(os.Stderr, "MOCK: ", log.Ltime|log.Lmicroseconds)
+}
+
+func TestAddLabelsToQueryStringFilters(t *testing.T) {
+	r := mockRulesDirector()
+	l := mockLogger()
+
+	// key = client side URL (inc query params)
+	// value = expected request URL on upstream side (inc query params)
+	// TODOLATER: would it be more elegant to write these as URL decoded for readability? will need to change the map[string]string to still send the full docker-compose ps URLs
+	tests := map[string]string{
+		// docker ps - without any filters
+		"/v1.32/containers/json": "/v1.32/containers/json?filters=%7B%22label%22%3A%5B%22com.buildkite.sockguard.owner%3Dtest-owner%22%5D%7D",
+		// docker ps - with a key=value: true filter
+		"/v1.32/containers/json?filters=%7B%22label%22%3A%7B%22test%3Dblah%22%3Atrue%7D%7D": "/v1.32/containers/json?filters=%7B%22label%22%3A%5B%22test%3Dblah%22%2C%22com.buildkite.sockguard.owner%3Dtest-owner%22%5D%7D",
+		// docker-compose ps - first list API call
+		"/v1.32/containers/json?limit=-1&all=1&size=0&trunc_cmd=0&filters=%7B%22label%22%3A+%5B%22com.docker.compose.project%3Dblah%22%2C+%22com.docker.compose.oneoff%3DFalse%22%5D%7D": "/v1.32/containers/json?all=1&filters=%7B%22label%22%3A%5B%22com.docker.compose.project%3Dblah%22%2C%22com.docker.compose.oneoff%3DFalse%22%2C%22com.buildkite.sockguard.owner%3Dtest-owner%22%5D%7D&limit=-1&size=0&trunc_cmd=0",
+		// docker-compose ps - second list API call
+		"/v1.32/containers/json?limit=-1&all=0&size=0&trunc_cmd=0&filters=%7B%22label%22%3A+%5B%22com.docker.compose.project%3Dblah%22%2C+%22com.docker.compose.oneoff%3DTrue%22%5D%7D": "/v1.32/containers/json?all=0&filters=%7B%22label%22%3A%5B%22com.docker.compose.project%3Dblah%22%2C%22com.docker.compose.oneoff%3DTrue%22%2C%22com.buildkite.sockguard.owner%3Dtest-owner%22%5D%7D&limit=-1&size=0&trunc_cmd=0",
+	}
+
+	for c_req_url, u_req_url := range tests {
+		upstream := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			// log.Printf("%s %s", req.Method, req.URL.String())
+			// Validate the request URL against expected.
+			if req.URL.String() != u_req_url {
+				decode_u_req_url, err1 := url.QueryUnescape(u_req_url)
+				decode_in_req_url, err2 := url.QueryUnescape(req.URL.String())
+				if err1 == nil && err2 == nil {
+					t.Errorf("Expected:\n%s\ngot:\n%s\n\n(URL decoded) Expected:\n%s\ngot:\n%s\n", u_req_url, req.URL.String(), decode_u_req_url, decode_in_req_url)
+				} else {
+					t.Errorf("Expected:\n%s\ngot:\n%s\n\n(errors trying to URL decode)\n", u_req_url, req.URL.String())
+				}
+			}
+
+			// Return empty JSON, the request is whats important not the response
+			fmt.Fprintf(w, `{}`)
+		})
+
+		// Credit: https://blog.questionable.services/article/testing-http-handlers-go/
+		// Create a request to pass to our handler
+		req, err := http.NewRequest("GET", c_req_url, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+		rr := httptest.NewRecorder()
+		handler := r.addLabelsToQueryStringFilters(l, req, upstream)
+
+		// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+		// directly and pass in our Request and ResponseRecorder.
+		handler.ServeHTTP(rr, req)
+
+		// Check the status code is what we expect.
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("%s : handler returned wrong status code: got %v want %v", c_req_url, status, http.StatusOK)
+		}
+
+		// Don't bother checking the response, it's not relevant in mocked context. The request side is more important here.
+	}
+}


### PR DESCRIPTION
I was having a hard time remembering why `addLabelsToQueryStringFilters` delegated to a `modifyRequestFilters`. This inlines that logic into the `addLabelsToQueryStringFilters` and marshals to `map[string][]string` as defined by https://docs.docker.com/engine/api/v1.30/#operation/ContainerList. 

Previously it was filtering out any existing owner labels in there, but this just keeps it simple and appends. Given filter labels are AND-ed, this will fail if someone tried to manually set an owner label, which I think is fine. 

Closes #24.