### PR TITLE
examples/cgroup_parent: use builder Dockerfile again

### DIFF
--- a/examples/cgroup_parent/Dockerfile
+++ b/examples/cgroup_parent/Dockerfile
@@ -1,8 +1,17 @@
-# Don't duplicate the build process
-FROM buildkite/sockguard:latest as built
+# Duplicated build process (to ../../Dockerfile), to ease iterating locally using this stack in containers
+# If there was an INCLUDE instruction in Dockerfile's we could avoid some duplication here.
+#
+# For real world usage, use buildkite/sockguard:latest from Docker Hub
+#
+FROM golang:1.10-alpine as builder
+RUN apk add --no-cache ca-certificates
+WORKDIR /go/src/github.com/buildkite/sockguard
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+  go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/sockguard
 
 # So we can get a shell if we need to dig around for local testing. Main Dockerfile uses scratch
 FROM alpine:3.8
-COPY --from=built /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=built /sockguard /sockguard
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go/bin/sockguard /sockguard
 ENTRYPOINT [ "/sockguard" ]


### PR DESCRIPTION
To ease local iteration of work (dual purpose docker-compose stack, example + local
dev).

@lox I know you suggested going for Docker Hub images (which I did before merging), an example of where this makes sense to retain is testing things like https://github.com/buildkite/sockguard/pull/27 quickly locally (faster feedback loop).

I'm just going to merge. If you heavily disagree or propose an alternative, feel free to PR against it :)