### PR TITLE
fix: Docker build failed because of missing build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.10-alpine as builder
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates git
+RUN go get github.com/kvz/logstreamer
 WORKDIR /go/src/github.com/buildkite/sockguard
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \


### PR DESCRIPTION
It seems like you added a dependency, but forgot to include it's sources to Dockerfile.

Now the Docker image cannot be built with following error:
```
$ docker-compose build 
Building sockguard
Step 1/10 : FROM golang:1.10-alpine as builder
 ---> bd36346540f3
Step 2/10 : RUN apk add --no-cache ca-certificates
 ---> Using cache
 ---> b55fd57bc17a
Step 3/10 : WORKDIR /go/src/github.com/buildkite/sockguard
 ---> Using cache
 ---> 1efea32789cc
Step 4/10 : COPY . .
 ---> 88cc2eb2842c
Step 5/10 : RUN echo $PWD
 ---> Running in 14e56b830fbe
/go/src/github.com/buildkite/sockguard
Removing intermediate container 14e56b830fbe
 ---> 4ac04714d2f3
Step 6/10 : RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64   go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/sockguard
 ---> Running in e41256dd6224
socketproxy/proxy.go:14:2: cannot find package "github.com/kvz/logstreamer" in any of:
	/usr/local/go/src/github.com/kvz/logstreamer (from $GOROOT)
	/go/src/github.com/kvz/logstreamer (from $GOPATH)
ERROR: Service 'sockguard' failed to build: The command '/bin/sh -c CGO_ENABLED=0 GOOS=linux GOARCH=amd64   go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/sockguard' returned a non-zero code: 1
```

With this fix it completes successfully.