### PR TITLE
Update docker to golang 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine as builder
+FROM golang:1.11-alpine as builder
 RUN apk add --no-cache ca-certificates
 WORKDIR /go/src/github.com/buildkite/sockguard
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.11-alpine as builder
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates git
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/buildkite/sockguard
+ADD go.mod go.sum ./
+RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
   go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/sockguard


### PR DESCRIPTION
This updates the dockerfile to use Golang 1.11 and Modules. 

See https://github.com/buildkite/sockguard/pull/42 for some more context.