### PR TITLE
docs: suggest using only awk instead of 4 separate processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ set -euo pipefail
 
 # A) Use the container ID from /proc/self/cgroup
 # (note: this works fine on a systemd based system, need to adjust the grep on pre-systemd? fine for us right now)
-container_id=$(cat /proc/self/cgroup | grep "1:name=systemd" | rev | cut -d/ -f1 | rev)
+container_id=$(awk -F/ '/1:name=systemd/ {print $NF}' /proc/self/cgroup)
 
 # B) Use the hostname
 # (note: works, as long as someone doesnt start the container with --hostname. A) preferred for now)


### PR DESCRIPTION
Note that awk is capable of all the thing you do with `cat /proc/self/cgroup | grep "1:name=systemd" | rev | cut -d/ -f1 | rev`:
- read file
- filter lines containing a pattern
- split using defined delimiter
- return only last "column"